### PR TITLE
🐛 skip rows with extra columns

### DIFF
--- a/importer/plugins/operators/extract_offices.py
+++ b/importer/plugins/operators/extract_offices.py
@@ -13,7 +13,7 @@ from labonneboite_common.siret import is_siret
 from sqlalchemy import ColumnDefault
 
 from models import ExportableOffice
-from utils.csv import SemiColonDialect
+from utils.csv import UnquotedSemiColonDialect
 from utils.get_departement_from_zipcode import get_department_from_zipcode
 
 if TYPE_CHECKING:
@@ -246,7 +246,7 @@ class ExtractOfficesOperator(BaseOperator):
             my_file,
             Office._fields,
             restkey=self.__class__.REST_KEY,
-            dialect=SemiColonDialect
+            dialect=UnquotedSemiColonDialect
         )
 
         return reader

--- a/importer/plugins/utils/csv.py
+++ b/importer/plugins/utils/csv.py
@@ -3,3 +3,11 @@ import csv
 
 class SemiColonDialect(csv.unix_dialect):
     delimiter = ";"
+
+
+class UnquotedDialect(csv.unix_dialect):
+    quoting = csv.QUOTE_NONE
+
+
+class UnquotedSemiColonDialect(SemiColonDialect, UnquotedDialect):
+    pass

--- a/importer/tests/data/.gitignore
+++ b/importer/tests/data/.gitignore
@@ -1,0 +1,1 @@
+huge_test.csv

--- a/importer/tests/data/invalids/etablissements_with_extra_row.csv
+++ b/importer/tests/data/invalids/etablissements_with_extra_row.csv
@@ -1,3 +1,0 @@
-siret;raisonsociale;enseigne;codenaf;numerorue;libellerue;codecommune;codepostal;email;tel;trancheeffectif;website;flag_poe_afpr;flag_pmsmp;flag_junior;flag_senior;flag_handicap
-00000000001941;ASS MUSARAILE;;9312Z;5;SQUARE GEORGES GUYON;94046;94700;;0143565222;NULL;;0;0;NULL;NULL;NULL;extra
-00000000001941;ASS MUSARAILE;;9312Z;5;SQUARE GEORGES GUYON;94046;94700;;0143565222;NULL;;0;0;NULL;NULL;NULL;NULL

--- a/importer/tests/data/invalids/etablissements_with_extra_row.csv
+++ b/importer/tests/data/invalids/etablissements_with_extra_row.csv
@@ -1,0 +1,3 @@
+siret;raisonsociale;enseigne;codenaf;numerorue;libellerue;codecommune;codepostal;email;tel;trancheeffectif;website;flag_poe_afpr;flag_pmsmp;flag_junior;flag_senior;flag_handicap
+00000000001941;ASS MUSARAILE;;9312Z;5;SQUARE GEORGES GUYON;94046;94700;;0143565222;NULL;;0;0;NULL;NULL;NULL;extra
+00000000001941;ASS MUSARAILE;;9312Z;5;SQUARE GEORGES GUYON;94046;94700;;0143565222;NULL;;0;0;NULL;NULL;NULL;NULL

--- a/importer/tests/operators/extract_offices_tests.py
+++ b/importer/tests/operators/extract_offices_tests.py
@@ -1,14 +1,19 @@
+import os.path
 from os.path import dirname, join
 from typing import Optional
-from unittest import TestCase
-from unittest.mock import Mock, MagicMock, patch, call
+from unittest import TestCase, skipUnless
+from unittest.mock import Mock, MagicMock, patch, call, mock_open
 
+import _csv
 from airflow.hooks.filesystem import FSHook
 from airflow.providers.mysql.hooks.mysql import MySqlHook
 
 from operators.extract_offices import ExtractOfficesOperator, Office, FIELDS
 
 TEST_DIR = join(dirname(dirname(dirname(__file__))), 'tests')
+
+VALID_HEADER = 'siret;raisonsociale;enseigne;codenaf;numerorue;libellerue;codecommune;codepostal;email;tel;' \
+               'trancheeffectif;website;flag_poe_afpr;flag_pmsmp;flag_junior;flag_senior;flag_handicap'
 
 
 def create_office(**overloaded_kwargs):
@@ -52,7 +57,19 @@ class TestExtractOfficesOperator(TestCase):
                                           chunk_size=5,
                                           _fs_hook=mock_fs_hook,
                                           _mysql_hook=mock_mysql_hook)
-        operator.execute({})
+        return operator.execute({})
+
+    def execute_with_file_content(self, _mysql_hook: Optional[MySqlHook] = None, header=VALID_HEADER,
+                                  **overloaded_values: str):
+        file_content = create_office(**overloaded_values)
+        csv_fields = [file_content.siret, file_content.raisonsociale, file_content.enseigne, file_content.codenaf,
+                      file_content.numerorue, file_content.libellerue, file_content.codecommune,
+                      file_content.codepostal, file_content.email, file_content.tel, file_content.trancheeffectif,
+                      file_content.website, file_content.flag_poe_afpr, file_content.flag_pmsmp,
+                      file_content.flag_junior, file_content.flag_senior, file_content.flag_handicap]
+        mocked_open = mock_open(read_data=f"{header}\n{';'.join(csv_fields)}\n")
+        with patch('operators.extract_offices.open', mocked_open):
+            return self.execute(offices_filename='memory', _mysql_hook=_mysql_hook)
 
     def test_coherence_between_FIELDS_and_Office_props(self):
         missing_fields = set(FIELDS) - set(vars(Office))
@@ -162,7 +179,28 @@ class TestExtractOfficesOperator(TestCase):
         mock_mysql_hook.run.assert_not_called()
 
     def test_file_with_extra_column_should_skip_it(self):
+        raisonsociale_with_semicolon = "SQUARE GEORGES; GUYON"
+        insert_rows_mock = MagicMock(MySqlHook)
+
+        nb_inserted_sirets = self.execute_with_file_content(_mysql_hook=insert_rows_mock,
+                                                            raisonsociale=raisonsociale_with_semicolon)
+
+        self.assertEqual(0, nb_inserted_sirets)
+
+    def test_quotes_should_be_treated(self):
+        insert_rows_mock = Mock()
+        mock_mysql_hook = MagicMock(MySqlHook, insert_rows=insert_rows_mock)
+
+        nb_inserted_sirets = self.execute_with_file_content(raisonsociale='"quoted name', _mysql_hook=mock_mysql_hook)
+
+        self.assertEqual(1, nb_inserted_sirets)
+        insert_rows__args = insert_rows_mock.call_args[0]
+        insert_rows__rows = insert_rows__args[1]
+        self.assertIn('"quoted name', insert_rows__rows[0], 'the raison social should have the quote')
+
+    @skipUnless(os.path.exists(join(TEST_DIR, 'data', 'huge_test.csv')), 'huge_test doesn\'t exists')
+    def test_file_with_huge_file(self):
         try:
-            self.execute(offices_filename=join(TEST_DIR, 'data', 'invalids', 'etablissements_with_extra_row.csv'))
-        except AssertionError:
-            self.fail("With extra row the execution should succeed")
+            self.execute(offices_filename=join(TEST_DIR, 'data', 'huge_test.csv'))
+        except _csv.Error:
+            self.fail("Huge file should succeed")


### PR DESCRIPTION
- 🐛 if the csv contains a quote in the name or anywhere the csv parser don't treat it anymore
- 🔊 add error details
- 🐛 skip rows with extra columns