### PR TITLE
🐛 handle invalid fields in the company source file

### DIFF
--- a/importer/plugins/operators/extract_offices.py
+++ b/importer/plugins/operators/extract_offices.py
@@ -46,6 +46,24 @@ FIELDS = [
     "flag_pmsmp"
 ]
 
+TRANCHEEFFECTIF_MAP = {
+    "0-0": "00",
+    "1-2": "01",
+    "3-5": "02",
+    "6-9": "03",
+    "10-19": "11",
+    "20-49": "12",
+    "50-99": "21",
+    "100-199": "22",
+    "200-249": "31",
+    "250-499": "32",
+    "500-999": "41",
+    "1000-1999": "42",
+    "2000-4999": "51",
+    "5000-9999": "52",
+    "10000+": "53",
+}
+
 
 def add_quote(string: str, quote: str = '"') -> str:
     return quote + string + quote
@@ -289,8 +307,14 @@ class ExtractOfficesOperator(BaseOperator):
             if self._has_extra_columns(csv_row):
                 self.log.error(f"Invalid row for siret {csv_row['siret']} : has extra column")
                 continue
+            csv_row = self.map_fields(csv_row)
             office_without_null = Office.without_nulls(**csv_row)
             yield office_without_null
+
+    @classmethod
+    def map_fields(cls, csv_row: Dict[str, str]) -> Dict[str, str]:
+        csv_row['trancheeffectif'] = TRANCHEEFFECTIF_MAP.get(csv_row['trancheeffectif'], csv_row['trancheeffectif'])
+        return csv_row
 
     @classmethod
     def _has_extra_columns(cls, csv_entry: Dict[str, str]) -> bool:

--- a/importer/plugins/operators/extract_offices.py
+++ b/importer/plugins/operators/extract_offices.py
@@ -152,9 +152,18 @@ class Office(NamedTuple):
         return errors
 
     def _check_field(self, column: sqla.Column, value: Optional[str]) -> Iterable[str]:
+        errors = []
+        errors.extend(self._check_nullable(column, value))
         if isinstance(column.type, sqla.String):
-            return self._check_string_field(column, value)
-        return []
+            errors.extend(self._check_string_field(column, value))
+        return errors
+
+    @staticmethod
+    def _check_nullable(column: sqla.Column, value: Optional) -> Iterable[str]:
+        errors = []
+        if value is None and not column.nullable:
+            errors.append(f"invalid {column.key}: column cannot be null")
+        return errors
 
     @staticmethod
     def _check_string_field(column: sqla.Column, value: Optional[str]) -> Iterable[str]:

--- a/importer/plugins/utils/get_departement_from_zipcode.py
+++ b/importer/plugins/utils/get_departement_from_zipcode.py
@@ -3,8 +3,8 @@ from typing import Optional
 
 
 @lru_cache(maxsize=128 * 1024)
-def get_department_from_zipcode(zipcode: str) -> Optional[str]:
-    zipcode = str(zipcode).strip()
+def get_department_from_zipcode(zipcode: Optional[str]) -> Optional[str]:
+    zipcode = str(zipcode).strip() if zipcode else ""
 
     if len(zipcode) == 1:
         department = "0%s" % zipcode[0]

--- a/importer/tests/operators/extract_offices_tests.py
+++ b/importer/tests/operators/extract_offices_tests.py
@@ -140,7 +140,26 @@ class TestExtractOfficesOperator(TestCase):
 
         self.assertEqual(1, nb_inserted_siret)
         result = mock_mysql_hook.insert_rows.call_args[0][1][0][FIELDS.index('trancheeffectif')]
-        self.assertEqual("00", result)
+        self.assertEqual("00", result, 'The "trancheeffectif" should be transform from "0-0" to "00"')
+
+    def test_row_with_invalid_trancheffectif(self):
+        nb_inserted_siret = self.execute_with_file_content(trancheeffectif='0-2')
+
+        self.assertEqual(0, nb_inserted_siret, 'rows with invalid "trancheeffectif" should be skip')
+
+    def test_row_with_NULL_trancheffectif(self):
+        mock_mysql_hook = MagicMock(MySqlHook)
+
+        nb_inserted_siret = self.execute_with_file_content(trancheeffectif='NULL', _mysql_hook=mock_mysql_hook)
+
+        self.assertEqual(1, nb_inserted_siret, 'rows with NULL "trancheeffectif" should be add')
+        result = mock_mysql_hook.insert_rows.call_args[0][1][0][FIELDS.index('trancheeffectif')]
+        self.assertIsNone(result, 'The "trancheeffectif" should be add as "None"')
+
+    def test_row_with_null_raisonsociale_should_be_skip(self):
+        nb_inserted_siret = self.execute_with_file_content(raisonsociale='NULL')
+
+        self.assertEqual(0, nb_inserted_siret, 'rows with NULL in the "raisonsocial" shouldn\'t be treated')
 
     def test_NULL_values_are_saved_with_default(self):
         mock_mysql_hook = MagicMock(MySqlHook)

--- a/importer/tests/operators/extract_offices_tests.py
+++ b/importer/tests/operators/extract_offices_tests.py
@@ -133,6 +133,11 @@ class TestExtractOfficesOperator(TestCase):
             replace=True,
         )
 
+    def test_rows_with_trancheffectif_to_long_should_be_skip(self):
+        nb_inserted_siret = self.execute_with_file_content(trancheeffectif='200')
+
+        self.assertEqual(0, nb_inserted_siret)
+
     def test_NULL_values_are_saved_with_default(self):
         mock_mysql_hook = MagicMock(MySqlHook)
         mock_mysql_hook.insert_rows = Mock()

--- a/importer/tests/operators/extract_offices_tests.py
+++ b/importer/tests/operators/extract_offices_tests.py
@@ -133,10 +133,14 @@ class TestExtractOfficesOperator(TestCase):
             replace=True,
         )
 
-    def test_rows_with_trancheffectif_to_long_should_be_skip(self):
-        nb_inserted_siret = self.execute_with_file_content(trancheeffectif='200')
+    def test_trancheffectif_should_be_transformed(self):
+        mock_mysql_hook = MagicMock(MySqlHook)
 
-        self.assertEqual(0, nb_inserted_siret)
+        nb_inserted_siret = self.execute_with_file_content(trancheeffectif='0-0', _mysql_hook=mock_mysql_hook)
+
+        self.assertEqual(1, nb_inserted_siret)
+        result = mock_mysql_hook.insert_rows.call_args[0][1][0][FIELDS.index('trancheeffectif')]
+        self.assertEqual("00", result)
 
     def test_NULL_values_are_saved_with_default(self):
         mock_mysql_hook = MagicMock(MySqlHook)

--- a/importer/tests/utils/get_department_from_zipcode_tests.py
+++ b/importer/tests/utils/get_department_from_zipcode_tests.py
@@ -9,6 +9,9 @@ class GetDepartmentFromZipcodeTestCase(unittest.TestCase):
         department = get_department_from_zipcode("6600")
         self.assertEqual(department, "06")
 
+        department = get_department_from_zipcode(None)
+        self.assertEqual(department, None)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
- 🐛 exclude offices which raisonsocial is NULL
- 🐛 NULL zipcode are transform in None
- ✨ transform trancheeffectif from min-max to the INSEE : Tranche d'effectif salarié de l'entreprise (TEFEN)
- 🥅 exclude offices which fields are too long